### PR TITLE
Supply a mock through URLSessionConfiguration

### DIFF
--- a/Sources/URLRequestMocking/URLProtocolMock.swift
+++ b/Sources/URLRequestMocking/URLProtocolMock.swift
@@ -15,6 +15,8 @@ class URLProtocolMock: URLProtocol {
         }
     }
     
+    internal static var mock: (any URLRequestMocking)?
+    
     override public class func canInit(with task: URLSessionTask) -> Bool {
         return true
     }
@@ -22,7 +24,13 @@ class URLProtocolMock: URLProtocol {
     public let mock: any URLRequestMocking
 
     override public init(request: URLRequest, cachedResponse: CachedURLResponse?, client: URLProtocolClient?) {
-        mock = request.mock != nil ? request.mock! : ExceptionMock()
+        if request.mock != nil {
+            mock = request.mock!
+        } else if URLProtocolMock.mock != nil {
+            mock = URLProtocolMock.mock!
+        } else {
+            mock = ExceptionMock()
+        }
         super.init(request: request, cachedResponse: cachedResponse, client: client)
     }
     

--- a/Sources/URLRequestMocking/URLSessionConfigurationExtensions.swift
+++ b/Sources/URLRequestMocking/URLSessionConfigurationExtensions.swift
@@ -12,8 +12,9 @@ extension URLSessionConfiguration {
     /// Creates a mock based on the given ``URLSessionConfiguration``
     /// - Parameter configuration: an ``URLSessionConfiguration``
     /// - Returns: A mocked ``URLSessionConfiguration``
-    public class func mock(for configuration: URLSessionConfiguration) -> URLSessionConfiguration {
+    public class func mock(for configuration: URLSessionConfiguration, using mock: (any URLRequestMocking)? = nil) -> URLSessionConfiguration {
         configuration.protocolClasses = [URLProtocolMock.self]
+        URLProtocolMock.mock = mock
         return configuration
     }
 }


### PR DESCRIPTION
It is now possible to set a mock on the URLSessionConfiguration itself. It handles all incoming requests, but can be overriden if a mock is set on the incoming URLRequest.